### PR TITLE
added checks to handle goahead looping when connecting with Adtran

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -193,10 +193,15 @@ func (c *Conn) cmd(cmd byte) error {
 				err = c.wont(o)
 			}
 		case cmdWill:
-			err = c.do(o)
+			if !c.cliSuppressGoAhead {
+				c.cliSuppressGoAhead = true
+				err = c.do(o)
+			}
 		case cmdWont:
-			err = c.dont(o)
-
+			if c.cliSuppressGoAhead {
+				c.cliSuppressGoAhead = false
+				err = c.dont(o)
+			}
 		}
 	case optNAWS:
 		if cmd != cmdDo {


### PR DESCRIPTION
telnet connection would get stuck looping between the client and the adtran device trying to tell do goahead and willDo . Add the check so it doesn't send the option if already set.