### PR TITLE
Make window size negotiation RFC-compliant

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -218,7 +218,7 @@ func (c *Conn) cmd(cmd byte) error {
 			break
 		}
 		// Reply with max window size: 65535x65535
-		err = c.sub(o, 255, 255, 255, 255)
+		err = c.sub(o, 255, 255, 255, 255, 255, 255, 255, 255)
 	default:
 		// Deny any other option
 		err = c.deny(cmd, o)


### PR DESCRIPTION
Per RFC1073 section 2, the width and the height are two bytes each, but "any occurrence of 255 in the subnegotiation must be doubled to distinguish it from the IAC character (which has a value of 255).".  So we need to send _eight_ 255 bytes for a 65535x65535 terminal, not four.

For some reason, recent versions of Mikrotik RouterOS have started _really caring_ about this.